### PR TITLE
Add pre-commit hook for formatting and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.1
+    hooks:
+      - id: ruff
+        args: ["--fix", "--exclude", "notebooks/"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Fantasy Allsvenskan Optimiser
+
+This repository contains scripts for optimising fantasy football teams.
+
+## Development Setup
+
+Install `pre-commit` to automatically run formatters and linters on each
+commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The pre-commit configuration runs `isort`, `black` and `ruff`.

--- a/scripts/build_forecasts_batched.py
+++ b/scripts/build_forecasts_batched.py
@@ -1,11 +1,12 @@
 # scripts/build_forecasts_batched.py
+import warnings
 from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pymc as pm
 import pytensor.tensor as pt
-from tqdm import tqdm
-import warnings
+
 from fantasy_optimizer.api_client import fetch_bootstrap_static
 
 warnings.filterwarnings("ignore", category=UserWarning)
@@ -15,38 +16,49 @@ INPUT_FILE = DATA_DIR / "player_gameweek_stats.parquet"
 FIXTURES_FILE = DATA_DIR / "fixtures.parquet"
 OUTPUT_FILE = DATA_DIR / "player_forecasts.parquet"
 
+
 # --- Main Forecast Function ---
-def build_forecasts_batched(df: pd.DataFrame, fixtures: pd.DataFrame, last_n: int = 5) -> pd.DataFrame:
+def build_forecasts_batched(
+    df: pd.DataFrame, fixtures: pd.DataFrame, last_n: int = 5
+) -> pd.DataFrame:
     df = df[df["minutes"] > 0].copy()
     latest_round = df["round"].max()
     df_recent = df[df["round"] > latest_round - last_n].copy()
     df = df.merge(
         fixtures[["round", "team", "opponent_team", "was_home"]],
         how="left",
-        on=["round", "opponent_team", "was_home"]
+        on=["round", "opponent_team", "was_home"],
     )
 
     df_recent = df_recent.merge(
         fixtures[["round", "team", "opponent_team", "was_home"]],
         how="left",
-        on=["round", "opponent_team", "was_home"]
+        on=["round", "opponent_team", "was_home"],
     )
 
     bootstrap = fetch_bootstrap_static()
     players = pd.DataFrame(bootstrap["elements"])
-    teams = pd.DataFrame(bootstrap["teams"])
+    _teams = pd.DataFrame(bootstrap["teams"])
 
     # Add position
-    players["position"] = players["element_type"].map({1: "GK", 2: "DEF", 3: "MID", 4: "FWD"})
+    players["position"] = players["element_type"].map(
+        {1: "GK", 2: "DEF", 3: "MID", 4: "FWD"}
+    )
     position_map = {pos: i for i, pos in enumerate(players["position"].unique())}
     players["group_idx"] = players["position"].map(position_map)
 
-    df_recent = df_recent.merge(players[["id", "group_idx"]], left_on="element", right_on="id")
+    df_recent = df_recent.merge(
+        players[["id", "group_idx"]], left_on="element", right_on="id"
+    )
 
     # Team strength: average goals scored
-    df_recent["team_strength"] = df_recent.groupby("team")["goals_scored"].transform("mean")
+    df_recent["team_strength"] = df_recent.groupby("team")["goals_scored"].transform(
+        "mean"
+    )
     # Opponent weakness: average goals conceded
-    df_recent["opponent_weakness"] = df_recent.groupby("opponent_team")["goals_conceded"].transform("mean")
+    df_recent["opponent_weakness"] = df_recent.groupby("opponent_team")[
+        "goals_conceded"
+    ].transform("mean")
 
     # Assemble design matrix
     df_recent["log_minutes"] = np.log(df_recent["minutes"] + 1e-3)
@@ -60,10 +72,12 @@ def build_forecasts_batched(df: pd.DataFrame, fixtures: pd.DataFrame, last_n: in
     X_mean = X.mean(axis=0)
     X_std = X.std(axis=0) + 1e-3
     X_norm = (X - X_mean) / X_std
-    
+
     # PyMC model
-    with pm.Model() as model:
-        alpha_group = pm.Normal("alpha_group", mu=1.0, sigma=1.0, shape=len(position_map))
+    with pm.Model() as _model:
+        alpha_group = pm.Normal(
+            "alpha_group", mu=1.0, sigma=1.0, shape=len(position_map)
+        )
         beta = pm.Normal("beta", mu=0.0, sigma=1.0, shape=X.shape[1])
         sigma = pm.Exponential("sigma", 1.0)
 
@@ -75,17 +89,37 @@ def build_forecasts_batched(df: pd.DataFrame, fixtures: pd.DataFrame, last_n: in
 
     # --- Forecast next match ---
     latest_fixture = fixtures[fixtures["round"] == latest_round + 1].copy()
-    upcoming = players.merge(latest_fixture, left_on="team", right_on="team", how="inner")
-    upcoming = upcoming.rename(columns={"opponent_team": "opponent", "was_home": "home"})
-    upcoming = upcoming.merge(df.groupby("element")["minutes"].mean().rename("mean_minutes"), left_on="id", right_index=True, how="left")
+    upcoming = players.merge(
+        latest_fixture, left_on="team", right_on="team", how="inner"
+    )
+    upcoming = upcoming.rename(
+        columns={"opponent_team": "opponent", "was_home": "home"}
+    )
+    upcoming = upcoming.merge(
+        df.groupby("element")["minutes"].mean().rename("mean_minutes"),
+        left_on="id",
+        right_index=True,
+        how="left",
+    )
 
-    upcoming["team_strength"] = df.groupby("team")["goals_scored"].mean().reindex(upcoming["team"]).values
-    upcoming["opponent_weakness"] = df.groupby("opponent_team")["goals_conceded"].mean().reindex(upcoming["opponent"]).values
+    upcoming["team_strength"] = (
+        df.groupby("team")["goals_scored"].mean().reindex(upcoming["team"]).values
+    )
+    upcoming["opponent_weakness"] = (
+        df.groupby("opponent_team")["goals_conceded"]
+        .mean()
+        .reindex(upcoming["opponent"])
+        .values
+    )
 
     upcoming["log_minutes"] = np.log(upcoming["mean_minutes"] + 1e-3)
     upcoming["home"] = upcoming["home"].astype(float)
 
-    X_pred = upcoming[["log_minutes", "team_strength", "opponent_weakness", "home"]].fillna(0).values
+    X_pred = (
+        upcoming[["log_minutes", "team_strength", "opponent_weakness", "home"]]
+        .fillna(0)
+        .values
+    )
     X_pred_std = (X_pred - X_mean) / X_std
 
     alpha = trace.posterior["alpha_group"].mean(dim=("chain", "draw")).values

--- a/scripts/fetch_player_histories.py
+++ b/scripts/fetch_player_histories.py
@@ -1,9 +1,9 @@
-#sctipts/fetch_player_histories.py
-from fantasy_optimizer.api_client import fetch_bootstrap_static, fetch_player_history
-from fantasy_optimizer.models.gameweek import PlayerGameweekStat
-from pathlib import Path
+# sctipts/fetch_player_histories.py
 
 import pandas as pd
+
+from fantasy_optimizer.api_client import fetch_bootstrap_static, fetch_player_history
+from fantasy_optimizer.models.gameweek import PlayerGameweekStat
 
 data = fetch_bootstrap_static()
 player_ids = [p["id"] for p in data["elements"]]


### PR DESCRIPTION
## Summary
- add pre-commit configuration running isort, black and ruff
- document pre-commit setup in README
- tidy up build_forecasts_batched to satisfy ruff
- sort imports in fetch_player_histories

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black --check scripts/build_forecasts_batched.py scripts/fetch_player_histories.py`
- `ruff check --exclude notebooks/ scripts/build_forecasts_batched.py scripts/fetch_player_histories.py`
- `isort --profile black --check scripts/build_forecasts_batched.py scripts/fetch_player_histories.py`


------
https://chatgpt.com/codex/tasks/task_e_6861bec21bc8832f8ce356174d02bd3c